### PR TITLE
Use context instead of timeout

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -17,9 +17,11 @@ func main() {
 	}
 	path := os.Args[1]
 
-	ctx, _ := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 
-	data, err := ffprobe.GetProbeData(path, ctx)
+	defer cancel()
+
+	data, err := ffprobe.GetProbeData(ctx, path)
 	if err != nil {
 		log.Panicf("Error getting data: %v", err)
 	}

--- a/example/example.go
+++ b/example/example.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"os"
@@ -16,7 +17,9 @@ func main() {
 	}
 	path := os.Args[1]
 
-	data, err := ffprobe.GetProbeData(path, 500*time.Millisecond)
+	ctx, _ := context.WithTimeout(context.Background(), 500*time.Millisecond)
+
+	data, err := ffprobe.GetProbeData(path, ctx)
 	if err != nil {
 		log.Panicf("Error getting data: %v", err)
 	}

--- a/ffprobe.go
+++ b/ffprobe.go
@@ -25,7 +25,7 @@ func SetFFProbeBinPath(newBinPath string) {
 // GetProbeData is the main command used for probing the given media file using ffprobe.
 // A timeout can be provided to kill the process if it takes too long to determine
 // the files information.
-func GetProbeData(filePath string, ctx context.Context) (data *ProbeData, err error) {
+func GetProbeData(ctx context.Context, filePath string) (data *ProbeData, err error) {
 	cmd := exec.Command(
 		binPath,
 		"-v", "quiet",

--- a/ffprobe.go
+++ b/ffprobe.go
@@ -2,10 +2,10 @@ package ffprobe
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"os/exec"
-	"time"
 )
 
 var (
@@ -25,7 +25,7 @@ func SetFFProbeBinPath(newBinPath string) {
 // GetProbeData is the main command used for probing the given media file using ffprobe.
 // A timeout can be provided to kill the process if it takes too long to determine
 // the files information.
-func GetProbeData(filePath string, timeout time.Duration) (data *ProbeData, err error) {
+func GetProbeData(filePath string, ctx context.Context) (data *ProbeData, err error) {
 	cmd := exec.Command(
 		binPath,
 		"-v", "quiet",
@@ -51,7 +51,7 @@ func GetProbeData(filePath string, timeout time.Duration) (data *ProbeData, err 
 	}()
 
 	select {
-	case <-time.After(timeout):
+	case <-ctx.Done():
 		err = cmd.Process.Kill()
 		if err == nil {
 			return nil, ErrTimeout


### PR DESCRIPTION
We can now use context.WithTimeout or context.WithCancel to control the execution