### PR TITLE
Added two missing data stream constants & added to test

### DIFF
--- a/ffprobe_test.go
+++ b/ffprobe_test.go
@@ -84,14 +84,14 @@ func validateData(t *testing.T, data *ProbeData) {
 		t.Errorf("It does not have a subtitle stream.")
 	}
 
-	stream = data.StreamType(StreamAttachment)
-	if len(stream) != 0 {
-		t.Errorf("It does not have an attachment stream.")
-	}
-
 	stream = data.StreamType(StreamData)
 	if len(stream) != 0 {
 		t.Errorf("It does not have a data stream.")
+	}
+
+	stream = data.StreamType(StreamAttachment)
+	if len(stream) != 0 {
+		t.Errorf("It does not have an attachment stream.")
 	}
 
 	stream = data.StreamType(StreamAny)

--- a/ffprobe_test.go
+++ b/ffprobe_test.go
@@ -84,14 +84,24 @@ func validateData(t *testing.T, data *ProbeData) {
 		t.Errorf("It does not have a subtitle stream.")
 	}
 
+	stream = data.StreamType(StreamAttachment)
+	if len(stream) != 0 {
+		t.Errorf("It does not have an attachment stream.")
+	}
+
+	stream = data.StreamType(StreamData)
+	if len(stream) != 0 {
+		t.Errorf("It does not have a data stream.")
+	}
+
 	stream = data.StreamType(StreamAny)
 	if len(stream) != 2 {
 		t.Errorf("It should have two streams.")
 	}
 
 	// test Format.Duration
-	dration := data.Format.Duration()
-	if dration.Seconds() != 5.312 {
+	duration := data.Format.Duration()
+	if duration.Seconds() != 5.312 {
 		t.Errorf("this video is 5.312s.")
 	}
 	// test Format.StartTime

--- a/probedata.go
+++ b/probedata.go
@@ -16,10 +16,10 @@ const (
 	StreamAudio StreamType = "audio"
 	// StreamSubtitle is a subtitle stream
 	StreamSubtitle StreamType = "subtitle"
-	// StreamAttachment is an attachment stream
-	StreamAttachment StreamType = "attachment"
 	// StreamData is a data stream
 	StreamData StreamType = "data"
+	// StreamAttachment is an attachment stream
+	StreamAttachment StreamType = "attachment"
 )
 
 // ProbeData is the root json data structure returned by an ffprobe.
@@ -146,37 +146,35 @@ func (p *ProbeData) StreamType(streamType StreamType) (streams []Stream) {
 
 // FirstVideoStream returns the first video stream found
 func (p *ProbeData) FirstVideoStream() *Stream {
-	for _, s := range p.Streams {
-		if s == nil {
-			continue
-		}
-		if s.CodecType == string(StreamVideo) {
-			return s
-		}
-	}
-	return nil
+	return p.firstStream(StreamVideo)
 }
 
 // FirstAudioStream returns the first audio stream found
 func (p *ProbeData) FirstAudioStream() *Stream {
-	for _, s := range p.Streams {
-		if s == nil {
-			continue
-		}
-		if s.CodecType == string(StreamAudio) {
-			return s
-		}
-	}
-	return nil
+	return p.firstStream(StreamAudio)
 }
 
 // FirstSubtitleStream returns the first subtitle stream found
 func (p *ProbeData) FirstSubtitleStream() *Stream {
+	return p.firstStream(StreamSubtitle)
+}
+
+// FirstDataStream returns the first data stream found
+func (p *ProbeData) FirstDataStream() *Stream {
+	return p.firstStream(StreamData)
+}
+
+// FirstAttachmentStream returns the first attachment stream found
+func (p *ProbeData) FirstAttachmentStream() *Stream {
+	return p.firstStream(StreamAttachment)
+}
+
+func (p *ProbeData) firstStream(streamType StreamType) *Stream {
 	for _, s := range p.Streams {
 		if s == nil {
 			continue
 		}
-		if s.CodecType == string(StreamSubtitle) {
+		if s.CodecType == string(streamType) {
 			return s
 		}
 	}

--- a/probedata.go
+++ b/probedata.go
@@ -16,6 +16,10 @@ const (
 	StreamAudio StreamType = "audio"
 	// StreamSubtitle is a subtitle stream
 	StreamSubtitle StreamType = "subtitle"
+	// StreamAttachment is an attachment stream
+	StreamAttachment StreamType = "attachment"
+	// StreamData is a data stream
+	StreamData StreamType = "data"
 )
 
 // ProbeData is the root json data structure returned by an ffprobe.


### PR DESCRIPTION
Hey! 

While working on a project that utilizes your fantastic work here, I noticed from [here](https://trac.ffmpeg.org/wiki/Map) that there are firve stream types, two of which aren't declared in this project as constants (the `attachment` and `data` stream types).

Hopefully you have time to review and possibly merge this soon. Thanks!