### PR TITLE
Returning stderr in error when ffprobe fails

### DIFF
--- a/ffprobe.go
+++ b/ffprobe.go
@@ -22,7 +22,7 @@ func SetFFProbeBinPath(newBinPath string) {
 // Any additional ffprobe parameter can be supplied as well using extraFFProbeOptions.
 func ProbeURL(ctx context.Context, fileURL string, extraFFProbeOptions ...string) (data *ProbeData, err error) {
 	args := append([]string{
-		"-loglevel", "fatal",
+		"-loglevel", "error",
 		"-print_format", "json",
 		"-show_format",
 		"-show_streams",
@@ -43,7 +43,7 @@ func ProbeURL(ctx context.Context, fileURL string, extraFFProbeOptions ...string
 // Any additional ffprobe parameter can be supplied as well using extraFFProbeOptions.
 func ProbeReader(ctx context.Context, reader io.Reader, extraFFProbeOptions ...string) (data *ProbeData, err error) {
 	args := append([]string{
-		"-loglevel", "fatal",
+		"-loglevel", "error",
 		"-print_format", "json",
 		"-show_format",
 		"-show_streams",
@@ -70,10 +70,6 @@ func runProbe(cmd *exec.Cmd) (data *ProbeData, err error) {
 	err = cmd.Run()
 	if err != nil {
 		return nil, fmt.Errorf("error running %s [%s] %w", binPath, stdErr.String(), err)
-	}
-
-	if stdErr.Len() > 0 {
-		return nil, fmt.Errorf("ffprobe error: %s", stdErr.String())
 	}
 
 	data = &ProbeData{}

--- a/ffprobe.go
+++ b/ffprobe.go
@@ -22,7 +22,7 @@ func SetFFProbeBinPath(newBinPath string) {
 // Any additional ffprobe parameter can be supplied as well using extraFFProbeOptions.
 func ProbeURL(ctx context.Context, fileURL string, extraFFProbeOptions ...string) (data *ProbeData, err error) {
 	args := append([]string{
-		"-loglevel", "error",
+		"-loglevel", "fatal",
 		"-print_format", "json",
 		"-show_format",
 		"-show_streams",
@@ -43,7 +43,7 @@ func ProbeURL(ctx context.Context, fileURL string, extraFFProbeOptions ...string
 // Any additional ffprobe parameter can be supplied as well using extraFFProbeOptions.
 func ProbeReader(ctx context.Context, reader io.Reader, extraFFProbeOptions ...string) (data *ProbeData, err error) {
 	args := append([]string{
-		"-loglevel", "error",
+		"-loglevel", "fatal",
 		"-print_format", "json",
 		"-show_format",
 		"-show_streams",

--- a/ffprobe_test.go
+++ b/ffprobe_test.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	testPath = "assets/test.mp4"
+	testPath      = "assets/test.mp4"
+	testPathError = "assets/test.avi"
 )
 
 func Test_ProbeURL(t *testing.T) {
@@ -23,6 +24,16 @@ func Test_ProbeURL(t *testing.T) {
 	}
 
 	validateData(t, data)
+}
+
+func Test_ProbeURL_Error(t *testing.T) {
+	ctx, cancelFn := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelFn()
+
+	_, err := ProbeURL(ctx, testPathError)
+	if err == nil {
+		t.Errorf("No error reading bad asset")
+	}
 }
 
 func Test_ProbeURL_HTTP(t *testing.T) {
@@ -47,6 +58,11 @@ func Test_ProbeURL_HTTP(t *testing.T) {
 	}
 
 	validateData(t, data)
+
+	_, err = ProbeURL(ctx, fmt.Sprintf("http://127.0.0.1:%d/test.avi", testPort))
+	if err == nil {
+		t.Errorf("No error reading bad asset")
+	}
 }
 
 func Test_ProbeReader(t *testing.T) {
@@ -64,6 +80,21 @@ func Test_ProbeReader(t *testing.T) {
 	}
 
 	validateData(t, data)
+}
+
+func Test_ProbeReader_Error(t *testing.T) {
+	ctx, cancelFn := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelFn()
+
+	fileReader, err := os.Open(testPathError)
+	if err != nil {
+		t.Errorf("Error opening test file: %v", err)
+	}
+
+	_, err = ProbeReader(ctx, fileReader)
+	if err == nil {
+		t.Errorf("No error reading bad asset")
+	}
 }
 
 func validateData(t *testing.T, data *ProbeData) {

--- a/ffprobe_test.go
+++ b/ffprobe_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -30,9 +31,13 @@ func Test_ProbeURL_Error(t *testing.T) {
 	ctx, cancelFn := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancelFn()
 
-	_, err := ProbeURL(ctx, testPathError)
+	_, err := ProbeURL(ctx, testPathError, "-loglevel", "error")
 	if err == nil {
 		t.Errorf("No error reading bad asset")
+	}
+
+	if strings.Contains(err.Error(), "[]") {
+		t.Errorf("No stderr included in error message")
 	}
 }
 
@@ -59,9 +64,13 @@ func Test_ProbeURL_HTTP(t *testing.T) {
 
 	validateData(t, data)
 
-	_, err = ProbeURL(ctx, fmt.Sprintf("http://127.0.0.1:%d/test.avi", testPort))
+	_, err = ProbeURL(ctx, fmt.Sprintf("http://127.0.0.1:%d/test.avi", testPort), "-loglevel", "error")
 	if err == nil {
 		t.Errorf("No error reading bad asset")
+	}
+
+	if strings.Contains(err.Error(), "[]") {
+		t.Errorf("No stderr included in error message")
 	}
 }
 
@@ -91,9 +100,13 @@ func Test_ProbeReader_Error(t *testing.T) {
 		t.Errorf("Error opening test file: %v", err)
 	}
 
-	_, err = ProbeReader(ctx, fileReader)
+	_, err = ProbeReader(ctx, fileReader, "-loglevel", "error")
 	if err == nil {
 		t.Errorf("No error reading bad asset")
+	}
+
+	if strings.Contains(err.Error(), "[]") {
+		t.Errorf("No stderr included in error message")
 	}
 }
 


### PR DESCRIPTION
This pull request is so that error messages from ffprobe are reflected in returned errors. The current implementation sets `-loglevel fatal` which suppresses errors. Instead I'd like to use `-loglevel error` which returns all errors even those that can be recovered from but only return those errors if ffprobe itself returns a non-zero exit value.

Please let me know what you think. Thanks!
