### PR TITLE
fix: add flex bool

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: "1.24.x"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/sidedata.go
+++ b/sidedata.go
@@ -3,6 +3,7 @@ package ffprobe
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -39,8 +40,8 @@ type SideDataDisplayMatrix struct {
 // SideDataStereo3D represents the stereo 3D side data.
 type SideDataStereo3D struct {
 	SideDataBase
-	Type     string `json:"type"`
-	Inverted bool   `json:"inverted"`
+	Type     string   `json:"type"`
+	Inverted FlexBool `json:"inverted"`
 }
 
 // SideDataSphericalMapping represents the spherical mapping side data.
@@ -318,4 +319,41 @@ func (s *SideDataList) findSideDataByName(sideDataType string) (interface{}, boo
 		}
 	}
 	return nil, false
+}
+
+// FlexBool - handles JSON values that can be boolean, numeric (0 or 1), or string representations of boolean values ("true", "false", "yes", "no", "1", "0").
+type FlexBool bool
+
+func (fb *FlexBool) UnmarshalJSON(b []byte) error {
+	var bo bool
+	if err := json.Unmarshal(b, &bo); err == nil {
+		*fb = FlexBool(bo)
+
+		return nil
+	}
+
+	var num int
+	if err := json.Unmarshal(b, &num); err == nil {
+		*fb = num != 0
+
+		return nil
+	}
+
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		s = strings.ToLower(s)
+		if s == "1" || s == "true" || s == "yes" {
+			*fb = true
+
+			return nil
+		}
+
+		if s == "0" || s == "false" || s == "no" {
+			*fb = false
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("cannot unmarshal %s into FlexBool: %w", string(b), ErrSideDataUnexpectedType)
 }

--- a/sidedata_test.go
+++ b/sidedata_test.go
@@ -1454,3 +1454,56 @@ func Test_SideDataList_TypeMismatch(t *testing.T) {
 		})
 	}
 }
+
+func Test_FlexBool_UnmarshalJSON_Integer(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected FlexBool
+	}{
+		{
+			name:     "positive integer",
+			input:    `1`,
+			expected: FlexBool(true),
+		},
+		{
+			name:     "zero",
+			input:    `0`,
+			expected: FlexBool(false),
+		},
+		{
+			name:     "true",
+			input:    `true`,
+			expected: FlexBool(true),
+		},
+		{
+			name:     "false",
+			input:    `false`,
+			expected: FlexBool(false),
+		},
+		{
+			name:     "string bool false",
+			input:    `"false"`,
+			expected: FlexBool(false),
+		},
+
+		{
+			name:     "string bool true",
+			input:    `"true"`,
+			expected: FlexBool(true),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result FlexBool
+			err := json.Unmarshal([]byte(tt.input), &result)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
some video can have  inverted as int
```json
"side_data_list": [
                {
                    "side_data_type": "Stereo 3D",
                    "type": "top and bottom",
                    "inverted": 0,
                    "view": "packed",
                    "primary_eye": "none",
                    "baseline": 0,
                    "horizontal_disparity_adjustment": "0/1",
                    "horizontal_field_of_view": "0/1"
                },
                {
                    "side_data_type": "Spherical Mapping",
                    "projection": "equirectangular",
                    "yaw": 0,
                    "pitch": 0,
                    "roll": 0
                }
            ]
```